### PR TITLE
Added Entry to webpack.config.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,9 @@
 const path = require("path");
 
 module.exports = {
+  entry: [
+    path.join(__dirname, 'src', 'index.js')
+  ],
   output: {
     path: path.join(__dirname, "public"),
     filename: "main.js"


### PR DESCRIPTION
Kept receiving error
`WARNING in configuration
The 'mode' option has not been set, webpack will fallback to 'production' for this value. Set 'mode' option to 'development' or 'production' to enable defaults for each environment.
You can also set it to 'none' to disable any default behavior. Learn more: https://webpack.js.org/configuration/mode/
`
When running webpack using script
`"start:dev": "npm run webpack:dev & nodemon server/server.js --ignore public --ignore src"`

Added the following to `webpack.config.js` to resolve issue
```  entry: [
    path.join(__dirname, 'src', 'index.js')
  ],