### PR TITLE
Hotfix create user cart

### DIFF
--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -31,6 +31,7 @@ router.post('/', async (req, res, next) => {
       class: req.body.class,
       password: req.body.password,
     });
+    req.session.userId = newItem.id;
     res.status(201).send(newItem);
   } catch (err) {
     next(err);

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -31,7 +31,7 @@ router.post('/', async (req, res, next) => {
       class: req.body.class,
       password: req.body.password,
     });
-    req.session.userId = newItem.id;
+    req.session.userId = newItem.id; // eslint-disable-line require-atomic-updates
     res.status(201).send(newItem);
   } catch (err) {
     next(err);


### PR DESCRIPTION
Here is a quick one line fix for the problem that Schuyler brought up. 
Newly created users should be able to log out now with cart items, and not lose them.